### PR TITLE
feat: define `struct`/`enum` in a block for full flexibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ categories = [
 convert_case = "0.6.0"
 proc-macro2 = "1"
 quote = "1"
-syn = "2"
+syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
 macrotest = "1"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,47 @@ struct Author {
 </details>
 <br>
 
+Or, you can open a block and define struct like normal Rust code for full flexibility:
+
+```rust
+use nest_struct::nest_struct;
+
+#[nest_struct]
+struct Post {
+    title: String,
+    summary: String,
+    author: nest! {
+        /// doc comment for Author struct
+        #[derive(Debug)]
+        struct Author {
+            name: String,
+            handle: String,
+        }
+    },
+}
+```
+
+<details>
+ <summary>See expanded code</summary>
+
+```rust
+struct Post {
+    title: String,
+    summary: String,
+    author: Author,
+}
+
+/// doc comment for Author struct
+#[derive(Debug)]
+struct Author {
+    name: String,
+    handle: String,
+}
+```
+
+</details>
+<br>
+
 <details>
  <summary>Another example calling Pokemon API</summary>
 
@@ -123,8 +164,8 @@ For more examples, see the [`./tests/cases`](https://github.com/ZibanPirate/nest
 Feature parity with native Rust code:
 
 -   [x] `impl` block on inner `struct`s.
--   [ ] define `derive` and other attribute macros individually per inner `struct`.
--   [ ] define doc comments individually per inner `struct`.
+-   [x] define `derive` and other attribute macros individually per inner `struct`.
+-   [x] define doc comments individually per inner `struct`.
 -   [ ] useful compiler error messages.
 -   [x] support generic types.
 -   [x] support lifetimes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,47 @@
 //! </details>
 //! <br>
 //!
+//! Or, you can open a block and define struct like normal Rust code for full flexibility:
+//!
+//! ```rust
+//! use nest_struct::nest_struct;
+//!
+//! #[nest_struct]
+//! struct Post {
+//!     title: String,
+//!     summary: String,
+//!     author: nest! {
+//!         /// doc comment for Author struct
+//!         #[derive(Debug)]
+//!         struct Author {
+//!             name: String,
+//!             handle: String,
+//!         }
+//!     },
+//! }
+//! ```
+//!
+//! <details>
+//!  <summary>See expanded code</summary>
+//!
+//! ```rust
+//! struct Post {
+//!     title: String,
+//!     summary: String,
+//!     author: Author,
+//! }
+//!
+//! /// doc comment for Author struct
+//! #[derive(Debug)]
+//! struct Author {
+//!     name: String,
+//!     handle: String,
+//! }
+//! ```
+//!
+//! </details>
+//! <br>
+//!
 //! <details>
 //!  <summary>Another example calling Pokemon API</summary>
 //!
@@ -119,8 +160,8 @@
 //! Feature parity with native Rust code:
 //!
 //! -   [x] `impl` block on inner `struct`s.
-//! -   [ ] define `derive` and other attribute macros individually per inner `struct`.
-//! -   [ ] define doc comments individually per inner `struct`.
+//! -   [x] define `derive` and other attribute macros individually per inner `struct`.
+//! -   [x] define doc comments individually per inner `struct`.
 //! -   [ ] useful compiler error messages.
 //! -   [x] support generic types.
 //! -   [x] support lifetimes.

--- a/tests/cases/enum/8_full_flexibility.expanded.rs
+++ b/tests/cases/enum/8_full_flexibility.expanded.rs
@@ -1,0 +1,21 @@
+#![allow(dead_code)]
+#[macro_use]
+extern crate nest_struct;
+#[Derive(Debug)]
+struct CustomNameLast {
+    first: &'a str,
+    last: &'a str,
+}
+#[Derive(Debug)]
+/// Doc comment for CustomName
+enum CustomName {
+    First,
+    Last(CustomNameLast),
+}
+enum DeepNested<'a, AGE> {
+    Named { a: u32, b: u32 },
+    Unnamed(u32, u32),
+    None,
+    NestedEnum(CustomName, u32),
+    id(CustomName<'a>),
+}

--- a/tests/cases/enum/8_full_flexibility.rs
+++ b/tests/cases/enum/8_full_flexibility.rs
@@ -1,0 +1,31 @@
+#![allow(dead_code)]
+#[macro_use]
+extern crate nest_struct;
+
+#[nest_struct]
+enum DeepNested<AGE, 'a> {
+    Named {
+        a: u32,
+        b: u32,
+    },
+    Unnamed(u32, u32),
+    None,
+    NestedEnum(
+        // auto-generated name is overwritten to be CustomName
+        nest! {
+            #[Derive(Debug)]
+            /// Doc comment for CustomName
+            enum CustomName {
+                First,
+                Last (nest! {
+                    // generic are only used in the last nest
+                    first: &'a str,
+                    last: &'a str,
+                }),
+            }
+        },
+        u32,
+    ),
+    // now we reuse the auto-generated name
+    id(CustomName<'a>),
+}

--- a/tests/cases/struct/8_full_flexibility.expanded.rs
+++ b/tests/cases/struct/8_full_flexibility.expanded.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code)]
+#[macro_use]
+extern crate nest_struct;
+#[Derive(Debug)]
+struct ConfigServer<'a, P> {
+    name: &'a str,
+    host: &'a str,
+    port: P,
+    user: &'a str,
+    password: &'a str,
+}
+struct Config<'a, P> {
+    version: &'a str,
+    main_server: ConfigServer<'a, P>,
+    backup_server: ConfigServer<'a, P>,
+}

--- a/tests/cases/struct/8_full_flexibility.rs
+++ b/tests/cases/struct/8_full_flexibility.rs
@@ -1,0 +1,22 @@
+#![allow(dead_code)]
+#[macro_use]
+extern crate nest_struct;
+
+#[nest_struct]
+struct Config<P, 'a> {
+    version: &'a str,
+    // auto-generated name is overwritten to be ConfigServer
+    main_server: nest! {
+        // Doc comment for ConfigServer
+        #[Derive(Debug)]
+        struct ConfigServer<'a, P> {
+            name: &'a str,
+            host: &'a str,
+            port: P,
+            user: &'a str,
+            password: &'a str,
+        }
+    },
+    // now we reuse the auto-generated name
+    backup_server: ConfigServer<'a, P>,
+}


### PR DESCRIPTION
- define nested `struct`/`enum` like normal rust code inside `nest! { ... }` macro
- this enables defining doc comments and other attributes like macros
thanks again to @joelparkerhenderson for the feedback